### PR TITLE
Add ability to accept arbitrary int base.

### DIFF
--- a/include/docstrings.h
+++ b/include/docstrings.h
@@ -262,7 +262,7 @@ PyDoc_STRVAR(fast_float__doc__,
 
 
 PyDoc_STRVAR(fast_int__doc__, 
-"fast_int(x, default=None, raise_on_invalid=False, key=None)\n"
+"fast_int(x, default=None, raise_on_invalid=False, key=None, base=10)\n"
 "Quickly convert input to an `int`.\n"
 "\n"
 "Any input that is valid for the built-in `int` (or `long` on Python2)\n"
@@ -290,6 +290,10 @@ PyDoc_STRVAR(fast_int__doc__,
 "    If given and the *input* cannot be converted, the input will be\n"
 "    passed to the callable object and its return value will be returned.\n"
 "    The function must take one and only one required argument.\n"
+"base : int, optional\n"
+"    Follows the rules of Python's built-in :func:`int`; see it's\n"
+"    documentation for your Python version. If given, the input\n"
+"    **must** be of type `str`.\n"
 "\n"
 "Returns\n"
 "-------\n"

--- a/include/object_handling.h
+++ b/include/object_handling.h
@@ -24,7 +24,7 @@ typedef enum PyNumberType { REAL, FLOAT, INT, INTLIKE, FORCEINT } PyNumberType;
 PyObject*
 PyObject_to_PyNumber(PyObject *obj, const PyNumberType type,
                      PyObject *inf_sub, PyObject *nan_sub,
-                     PyObject *pycoerce);
+                     PyObject *pycoerce, const int base);
 
 PyObject*
 PyObject_is_number(PyObject *obj, const PyNumberType type,

--- a/include/object_handling.h
+++ b/include/object_handling.h
@@ -29,7 +29,8 @@ PyObject_to_PyNumber(PyObject *obj, const PyNumberType type,
 PyObject*
 PyObject_is_number(PyObject *obj, const PyNumberType type,
                    PyObject *allow_inf, PyObject *allow_nan,
-                   PyObject *str_only, PyObject *num_only);
+                   PyObject *str_only, PyObject *num_only,
+                   const int base);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/include/parsing.h
+++ b/include/parsing.h
@@ -92,6 +92,9 @@ bool
 string_contains_integer(const char *str, const char *end);
 
 bool
+string_contains_integer_arbitrary_base(const char *str, const char *end, const int base);
+
+bool
 string_contains_non_overflowing_float(const char *str, const char *end);
 
 #ifdef __cplusplus

--- a/include/string_handling.h
+++ b/include/string_handling.h
@@ -31,7 +31,7 @@ convert_PyString_to_str(PyObject *input, const char** end, PyObject **bytes_obje
 PyObject*
 PyString_to_PyNumber(PyObject *obj, const PyNumberType type,
                      PyObject *inf_sub, PyObject *nan_sub,
-                     PyObject *pycoerce);
+                     PyObject *pycoerce, const int base);
 
 PyObject*
 PyString_is_number(PyObject *obj, const PyNumberType type,

--- a/include/string_handling.h
+++ b/include/string_handling.h
@@ -35,7 +35,8 @@ PyString_to_PyNumber(PyObject *obj, const PyNumberType type,
 
 PyObject*
 PyString_is_number(PyObject *obj, const PyNumberType type,
-                   PyObject *allow_inf, PyObject *allow_nan);
+                   PyObject *allow_inf, PyObject *allow_nan,
+                   const int base);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/check_object_is_number.c
+++ b/src/check_object_is_number.c
@@ -15,7 +15,8 @@
 PyObject*
 PyObject_is_number(PyObject *obj, const PyNumberType type,
                    PyObject *allow_inf, PyObject *allow_nan,
-                   PyObject *str_only, PyObject *num_only)
+                   PyObject *str_only, PyObject *num_only,
+                   const int base)
 {
     PyObject *pyresult = NULL;
 
@@ -29,7 +30,7 @@ PyObject_is_number(PyObject *obj, const PyNumberType type,
         Py_RETURN_FALSE;
 
     /* Assume a string. */
-    pyresult = PyString_is_number(obj, type, allow_inf, allow_nan);
+    pyresult = PyString_is_number(obj, type, allow_inf, allow_nan, base);
     if (pyresult != Py_None)
         return pyresult;
 

--- a/src/check_string_is_number.c
+++ b/src/check_string_is_number.c
@@ -6,12 +6,14 @@
  * January 2017
  */
 
+#include <limits.h>
 #include "string_handling.h"
 #include "parsing.h"
 
 PyObject*
 PyString_is_number(PyObject *obj, const PyNumberType type,
-                   PyObject *allow_inf, PyObject *allow_nan)
+                   PyObject *allow_inf, PyObject *allow_nan,
+                   const int base)
 {
     const char* end;
     bool result = false;
@@ -27,7 +29,10 @@ PyString_is_number(PyObject *obj, const PyNumberType type,
                                            PyObject_IsTrue(allow_nan));
             break;
         case INT:
-            result = string_contains_integer(str, end);
+            if (base == INT_MIN || base == 10)
+                result = string_contains_integer(str, end);
+            else
+                result = string_contains_integer_arbitrary_base(str, end, base);
             break;
         case FORCEINT:
         case INTLIKE:

--- a/src/fastnumbers.c
+++ b/src/fastnumbers.c
@@ -109,15 +109,16 @@ fastnumbers_fast_int(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *raise_on_invalid = Py_False;
     PyObject *default_value = NULL;
     PyObject *key = NULL;
+    int base = 10;
     PyObject *pyreturn = NULL;
     static char *keywords[] = { "x", "default", "raise_on_invalid",
-                                "key", NULL };
-    static const char *format = "O|OOO:fast_int";
+                                "key", "base", NULL };
+    static const char *format = "O|OOOi:fast_int";
 
     /* Read the function argument. */
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, format, keywords,
                                      &input, &default_value, &raise_on_invalid,
-                                     &key))
+                                     &key, &base))
         return NULL;
 
     pyreturn = PyObject_to_PyNumber(input, INT, NULL, NULL, Py_False);

--- a/src/fastnumbers.c
+++ b/src/fastnumbers.c
@@ -180,7 +180,7 @@ fastnumbers_isreal(PyObject *self, PyObject *args, PyObject *kwargs)
 
     return PyObject_is_number(input, REAL,
                               allow_inf, allow_nan,
-                              str_only, num_only);
+                              str_only, num_only, INT_MIN);
 }
 
 
@@ -205,7 +205,7 @@ fastnumbers_isfloat(PyObject *self, PyObject *args, PyObject *kwargs)
 
     return PyObject_is_number(input, FLOAT,
                               allow_inf, allow_nan,
-                              str_only, num_only);
+                              str_only, num_only, INT_MIN);
 }
 
 
@@ -216,15 +216,22 @@ fastnumbers_isint(PyObject *self, PyObject *args, PyObject *kwargs)
     PyObject *input = NULL;
     PyObject *str_only = Py_False;
     PyObject *num_only = Py_False;
-    static char *keywords[] = { "x", "str_only", "num_only", NULL };
-    static const char *format = "O|OO:isint";
+    int base = INT_MIN;
+    static char *keywords[] = { "x", "str_only", "num_only", "base", NULL };
+    static const char *format = "O|OOi:isint";
 
     /* Read the function argument. */
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, format, keywords,
-                                     &input, &str_only, &num_only))
+                                     &input, &str_only, &num_only, &base))
         return NULL;
 
-    return PyObject_is_number(input, INT, NULL, NULL, str_only, num_only);
+    /* Ensure the base is in a valid range. */
+    if (base != INT_MIN && (base == 1 || base > 36 || base < 0)) {
+        PyErr_SetString(PyExc_ValueError,
+                        "ValueError: int() base must be >= 2 and <= 36");
+        return NULL;
+    }
+    return PyObject_is_number(input, INT, NULL, NULL, str_only, num_only, base);
 }
 
 
@@ -243,7 +250,8 @@ fastnumbers_isintlike(PyObject *self, PyObject *args, PyObject *kwargs)
                                      &input, &str_only, &num_only))
         return NULL;
 
-    return PyObject_is_number(input, INTLIKE, NULL, NULL, str_only, num_only);
+    return PyObject_is_number(input, INTLIKE, NULL, NULL,
+                              str_only, num_only, INT_MIN);
 }
 
 

--- a/src/string_contains_integer.c
+++ b/src/string_contains_integer.c
@@ -3,7 +3,7 @@
 #include "parsing.h"
 
 bool
-string_contains_integer (const char *str, const char *end)
+string_contains_integer(const char *str, const char *end)
 {
     register bool valid = false;
     (void) consume_sign(str);
@@ -13,4 +13,81 @@ string_contains_integer (const char *str, const char *end)
     }
     (void) consume_python2_long_literal_lL(str);
     return valid && str == end;
+}
+
+
+static bool
+is_valid_digit_arbitrary_base(const char c, const int base);
+
+
+bool
+string_contains_integer_arbitrary_base(const char *str, const char *end, const int base)
+{
+    register bool valid = false;
+    register int actual_base = base;
+    register size_t len = 0;
+
+    (void) consume_sign(str);
+    len = end - str;
+
+    /* This if-block lifted from Python source code. */
+    if (base == 0) {
+        /* No base given. Deduce the base from the contents
+         * of the string
+         */
+        if (str[0] != '0' || len == 1)
+            return string_contains_integer(str, end);  /* Base-10 */
+        else if (str[1] == 'x' || str[1] == 'X')
+            actual_base = 16;
+        else if (str[1] == 'o' || str[1] == 'O')
+            actual_base = 8;
+        else if (str[1] == 'b' || str[1] == 'B')
+            actual_base = 2;
+        else
+            /* "old" (C-style) octal literal, still valid in
+             * 2.x, although illegal in 3.x.
+             */
+#if PY_MAJOR_VERSION == 2
+            actual_base = 8;
+#else
+            return false;
+#endif
+    }
+
+    /* This if-block also lifted from Python source code.
+     * Skips leading characters.
+     */
+    if (len > 1 && str[0] == '0' &&
+        ((actual_base == 16 && (str[1] == 'x' || str[1] == 'X')) ||
+         (actual_base == 8  && (str[1] == 'o' || str[1] == 'O')) ||
+         (actual_base == 2  && (str[1] == 'b' || str[1] == 'B')))) {
+        str += 2;
+    }
+
+    /* The rest behaves as normal. */
+    while (is_valid_digit_arbitrary_base(*str, actual_base)) {
+        str++;
+        valid = true;
+    }
+#if PY_MAJOR_VERSION == 2
+    if (actual_base == 2 || actual_base == 8 ||
+        actual_base == 10 || actual_base == 16) {
+        (void) consume_python2_long_literal_lL(str);
+    }
+#endif
+    return valid && str == end;
+}
+
+
+bool
+is_valid_digit_arbitrary_base(const char c, const int base)
+{
+    /* We know base 10 will not be given here. */
+    if (base < 10)
+        return c >= '0' && c <= ((int) '0' + base);
+    else {
+        char offset = (char) base - 10;
+        return (c >= '0' && c <= '9') ||
+               ((c >= 'a'|| c >= 'A') && (c < ('a' + offset) || c < ('A' + offset)));
+    }
 }

--- a/tests/test_fastnumbers.py
+++ b/tests/test_fastnumbers.py
@@ -656,20 +656,21 @@ def test_fast_int_given_int_returns_int(x):
     assert isinstance(fastnumbers.fast_int(x), (int, long))
 
 
-@given(integers(), integers(2, 36))
-@example(40992764608243448035, 10)
-@example(-41538374848935286698640072416676709, 10)
-@example(240278958776173358420034462324117625982, 10)
-@example(1609422692302207451978552816956662956486, 10)
-@example(-121799354242674784350540853922878239740762834, 10)
-@example(32718704454132572934419741118153895444518280065843028297496525078, 10)
-@example(33684944745210074227862907273261282807602986571245071790093633147269, 10)
-def test_fast_int_given_int_string_returns_int(x, base):
+@given(integers())
+@example(40992764608243448035)
+@example(-41538374848935286698640072416676709)
+@example(240278958776173358420034462324117625982)
+@example(1609422692302207451978552816956662956486)
+@example(-121799354242674784350540853922878239740762834)
+@example(32718704454132572934419741118153895444518280065843028297496525078)
+@example(33684944745210074227862907273261282807602986571245071790093633147269)
+def test_fast_int_given_int_string_returns_int(x):
     y = repr(x)
     assert fastnumbers.fast_int(y) == x
     assert isinstance(fastnumbers.fast_int(y), (int, long))
-    if len(y) < 30:  # Avoid recursion error because of overly simple baseN function.
-        assert fastnumbers.fast_int(baseN(x, base), base=base) == x
+    for base in range(2, 36+1):
+        if len(y) < 30:  # Avoid recursion error because of overly simple baseN function.
+            assert fastnumbers.fast_int(baseN(x, base), base=base) == x
     assert fastnumbers.fast_int(bin(x), base=2) == x
     assert fastnumbers.fast_int(bin(x), base=0) == x
     assert fastnumbers.fast_int(oct(x), base=8) == x
@@ -1188,6 +1189,18 @@ def test_isint_returns_True_if_given_int_string_padded_or_not(x, y, z):
     assert fastnumbers.isint(repr(x)) is True
     assert fastnumbers.isint(repr(x), str_only=True)
     assert fastnumbers.isint(y)
+    for base in range(2, 36 + 1):
+        if len(repr(x)) < 30:  # Avoid recursion error because of overly simple baseN function.
+            assert fastnumbers.isint(baseN(x, base), base=base)
+    assert fastnumbers.isint(bin(x), base=2)
+    assert fastnumbers.isint(bin(x), base=0)
+    assert fastnumbers.isint(oct(x), base=8)
+    assert fastnumbers.isint(oct(x), base=0)
+    if python_version_tuple()[0] == '2':
+        assert fastnumbers.isint(oct(x).replace('0o', '0'), base=8)
+        assert fastnumbers.isint(oct(x).replace('0o', '0'), base=0)
+    assert fastnumbers.isint(hex(x), base=16)
+    assert fastnumbers.isint(hex(x), base=0)
 
 
 @given(floats(), integers(0, 100), integers(0, 100))
@@ -1197,6 +1210,9 @@ def test_isint_returns_False_if_given_float_string_padded_or_not(x, y, z):
     y = ''.join(repeat(' ', y)) + repr(x) + ''.join(repeat(' ', z))
     assert not fastnumbers.isint(repr(x))
     assert not fastnumbers.isint(y)
+    for base in range(2, 36 + 1):
+        if len(y) < 30:  # Avoid recursion error because of overly simple baseN function.
+            assert not fastnumbers.isint(y, base=base)
 
 
 @given(integers())

--- a/tests/test_fastnumbers_examples.py
+++ b/tests/test_fastnumbers_examples.py
@@ -232,6 +232,7 @@ def test_fast_int():
     # 18. Unicode numbers
     assert fastnumbers.fast_int(u'⑦') == 7
     assert fastnumbers.fast_int(u'⁸') == 8
+    assert fastnumbers.fast_int(u'⁸', base=10) == u'⁸'
     assert fastnumbers.fast_int(u'⅔') == u'⅔'
     assert fastnumbers.fast_int(u'Ⅴ') == u'Ⅴ'
     # 19. Key function


### PR DESCRIPTION
If a user wants to use fast_int to convert strings in binary, they should be able to do so.
This update adds the base option to fast_int and isint. It behaves in the same way
as the built-in int.