### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     version='2.0.4',
     ext_modules=[
         Extension(
-            'fastnumbers', glob.glob('src/*.c'),
+            'fastnumbers', sorted(glob.glob('src/*.c')),
             include_dirs=[os.path.abspath(os.path.join('include'))],
             extra_compile_args=[]
         )


### PR DESCRIPTION
Sort input file list
so that fastnumbers.so builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

Without this patch, the python-fastnumbers package in openSUSE differed for every build (that happens in a disposable VM).