### PR TITLE
Avoid coercing nan or inf to int in fast_real.

### DIFF
--- a/src/convert_string_to_number.c
+++ b/src/convert_string_to_number.c
@@ -45,8 +45,12 @@ str_to_PyInt_or_PyFloat(const char *str, const char *end,
     pyresult = str_to_PyFloat(str, end, options);
     if (pyresult == NULL) return NULL;
 
-    /* Coerce to int if needed. */
-    return (Options_Coerce_True(options) && string_contains_intlike_float(str, end))
+    /* Coerce to int if needed. Don't do it for NAN or INF. */
+    return (Options_Coerce_True(options)
+            && string_contains_intlike_float(str, end)
+            && !PyNumber_IsNAN(pyresult)
+            && !PyNumber_IsINF(pyresult)
+           )
          ? PyFloat_to_PyInt(pyresult, options)
          : pyresult;
 }

--- a/tests/test_fastnumbers.py
+++ b/tests/test_fastnumbers.py
@@ -240,6 +240,12 @@ def test_fast_real_given_inf_string_returns_inf():
     assert fastnumbers.fast_real('-infINIty') == float('-inf')
 
 
+def test_fast_real_given_very_large_float_returns_inf_with_coerce_on_or_off():
+    assert fastnumbers.fast_real('3e106196') == float('inf')
+    assert fastnumbers.fast_real('3e106196', coerce=False) == float('inf')
+    assert fastnumbers.fast_real('3e106196', raise_on_invalid=True) == float('inf')
+
+
 def test_fast_real_with_inf_given_inf_string_returns_sub_value():
     assert fastnumbers.fast_real('inf', inf=10000.0) == 10000.0
 


### PR DESCRIPTION
If a very large float was given to fast_real and coerce was set to True,
then it would be blindly converted to an int even if the value was inf.
This created an OverflowError which is not desirable.

The solution is to explicitly check for inf and nan before attempting the
integer conversion.

This will fix #13.