### PR TITLE
Remove pipenv from development and documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,11 +50,11 @@ branches:
 
 install:
 - pip install -U pip
-- pip install codecov pipenv
-- pipenv install --dev --skip-lock
+- pip install codecov
+- pip install -r dev/requirements.txt
 
 before_script:
- - python dev/patch_doctest.py
+- python dev/patch_doctest.py
 
 script:
 - python setup.py install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,13 @@ Located in the `dev/` folder is development collateral such as formatting and
 patching scripts. The only development collateral not in the `dev/`
 folder are those files that are expected to exist in the the top-level directory
 (such as `setup.py`, `.travis.yml`, `appveyor.yml`, and `tox.ini`).
-`fastnumbers` uses [`pipenv`](https://github.com/pypa/pipenv) to manage dependencies
-and virtual environments - to get all your dependencies installed use the following.
+To get all your dependencies installed use the following:
 
 ```
-$ pipenv install --dev --skip-lock
+$ pip install -r dev-requirements.txt
 ```
+
+Although, it is easier to just use ``tox``.
 
 I do not have strong opinions on how one should contribute, so
 I have copy/pasted some text verbatim from the

--- a/Pipfile
+++ b/Pipfile
@@ -1,4 +1,0 @@
-[dev-packages]
-pytest = "*"
-pytest-faulthandler = "*"
-hypothesis = "*"

--- a/README.rst
+++ b/README.rst
@@ -172,16 +172,14 @@ execute
 
     $ tox
 
-If you do not wish to use ``tox``, you can install the testing dependencies and run the
-tests manually using `pytest <https://docs.pytest.org/en/latest/>`_ - ``fastnumbers``
-contains a ``Pipfile`` for use with `pipenv <https://github.com/pypa/pipenv>`_ that
-makes it easy for you to install the testing dependencies:
+If you do not wish to use ``tox``, you can install the testing dependencies with the
+``dev-requirements.txt`` file and then run the tests manually using
+`pytest <https://docs.pytest.org/en/latest/>`_.
 
 .. code-block:: sh
 
-    $ pipenv install --skip-lock --dev
-    $ pipenv install --skip-lock -e .
-    $ pipenv run pytest
+    $ pip install -r dev/requirements.txt
+    $ pytest
 
 Author
 ------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,8 @@ environment:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python -m pip install -U pip"
-  - "python -m pip install pipenv"
-  - "pipenv install --dev --skip-lock"
-  - "pipenv run python dev/patch_doctest.py"
+  - "python -m pip install -r dev/requirements.txt"
+  - "python dev/patch_doctest.py"
 
 build: false
 
@@ -31,9 +30,9 @@ test_script:
   # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
   # you can remove "build.cmd" from the front of the command, as it's
   # only needed to support those cases.
-  - "dev\\build.cmd pipenv run python setup.py install"
-  - "pipenv run python -m doctest fastnumbers"
-  - "pipenv run pytest --doctest-glob=README.rst"
+  - "dev\\build.cmd python setup.py install"
+  - "python -m doctest fastnumbers"
+  - "pytest --doctest-glob=README.rst"
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/dev/README.md
+++ b/dev/README.md
@@ -14,6 +14,7 @@ This file contains some files useful for development.
   whereby it cannot run tests on extension modules. This file
   makes a local copy of `doctest.py` and patches it to be able to run
   on extension modules.
+- `requirements.txt` - Requirements to run tests
 - `run_coverage.sh` - A small shell one-liner placed into a file that
   will compile `fastnumbers`, run all tests, then run `lcov` and
   `genhtml` to create an HTML coverage report. Only tested on OSX.

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,0 +1,3 @@
+pytest >= 3.5
+pytest-faulthandler
+hypothesis >= 3.8.0

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -151,15 +151,13 @@ execute
 
     $ tox
 
-If you do not wish to use ``tox``, you can install the testing dependencies and run the
-tests manually using `pytest <https://docs.pytest.org/en/latest/>`_ - ``fastnumbers``
-contains a ``Pipfile`` for use with `pipenv <https://github.com/pypa/pipenv>`_ that
-makes it easy for you to install the testing dependencies:
+If you do not wish to use ``tox``, you can install the testing dependencies with the
+``dev-requirements.txt`` file and then run the tests manually using
+`pytest <https://docs.pytest.org/en/latest/>`_.
 
 .. code-block:: sh
 
-    $ pipenv install --skip-lock --dev
-    $ pipenv install --skip-lock -e .
-    $ pipenv run pytest
+    $ pip install -r dev/requirements.txt
+    $ pytest
 
 :mod:`fastnumbers` uses `pytest <https://docs.pytest.org/en/latest/>`_ to run its tests.

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,8 @@ envlist = py27, py34, py35, py36, py37
 [testenv]
 passenv = CC CFLAGS
 skip_install = true
-deps = pipenv
+deps = -r dev-requirements.txt
 commands =
-    # Install dependencies into this virtual environment
-    pipenv install --dev --skip-lock
     # All versions need to build and patch doctest for testing the fastnumbers module.
     {envpython} dev/patch_doctest.py
     # Install into this virtual environment.


### PR DESCRIPTION
Pipenv keeps changing its API and causing my builds to fail. I am tired
of this. From now on, only pip will be used. Besides, Pipenv doesn't
make much sense for use in a library, anyway.