### PR TITLE
Add package metadata for license and README filetype

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,9 @@ author_email = drtuba78@gmail.com
 url = https://github.com/SethMMorton/fastnumbers
 description = Super-fast and clean conversions to numbers.
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 license = MIT
+license_file = LICENSE
 classifiers = 
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Science/Research


### PR DESCRIPTION
It appears that PyPI no longer shows your metadata if this is not included.

Closes #25 