### PR TITLE
Add -lm as floor() is used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
             sorted(glob.glob("src/*.c")),
             include_dirs=[os.path.abspath(os.path.join("include"))],
             extra_compile_args=[],
+            extra_link_args=["-lm"],
         )
     ],
 )


### PR DESCRIPTION
This fixes build on armv7hl:
/usr/bin/ld: build/temp.linux-armv8l-3.10/src/numbers.o: in function `_PyFloat_is_Intlike':
/home/iurt/rpmbuild/BUILD/fastnumbers-3.2.1/src/numbers.c:69: undefined reference to `floor'

Fixed #53 