### PR TITLE
Use std::variant and std::optional make error handling simpler

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set CFLAGS
         if: matrix.os == 'ubuntu-latest'
         # Need no optimization for code coverage
-        run: echo CFLAGS="--coverage -O0" >> $GITHUB_ENV
+        run: echo CFLAGS="--coverage -Og" >> $GITHUB_ENV
 
       - name: Build and Install Using pip
         if: matrix.os != 'ubuntu-latest'

--- a/include/fastnumbers/ctype_extractor.hpp
+++ b/include/fastnumbers/ctype_extractor.hpp
@@ -63,7 +63,7 @@ public:
 
         // Function to pass-through a valid value, handling the special
         // case of the value being NaN or INF and requiring a replacement.
-        auto handle_value = [this, input](const T value) -> T {
+        auto handle_value = [&](const T value) -> T {
             if constexpr (std::is_floating_point_v<T>) {
                 const bool replace_nan = !std::holds_alternative<std::monostate>(m_nan);
                 const bool replace_inf = !std::holds_alternative<std::monostate>(m_inf);

--- a/include/fastnumbers/evaluator.hpp
+++ b/include/fastnumbers/evaluator.hpp
@@ -100,32 +100,30 @@ private:
         switch (ntype) {
         case UserType::REAL:
             if (typeflags & nan_or_inf) {
-                return Payload(handle_nan_and_inf());
+                return handle_nan_and_inf();
             } else if (options().allow_coerce()) {
-                return Payload(m_parser.as_pyfloat(false, true));
+                return m_parser.as_pyfloat(false, true);
             } else if (typeflags & NumberType::Float) {
-                return Payload(m_parser.as_pyfloat());
+                return m_parser.as_pyfloat();
             } else {
-                return Payload(m_parser.as_pyint());
+                return m_parser.as_pyint();
             }
 
         case UserType::FLOAT:
             if (typeflags & nan_or_inf) {
-                return Payload(handle_nan_and_inf());
+                return handle_nan_and_inf();
             } else {
-                return Payload(m_parser.as_pyfloat());
+                return m_parser.as_pyfloat();
             }
 
         case UserType::INT:
         case UserType::INTLIKE:
         case UserType::FORCEINT:
             if (!options().is_default_base()) {
-                return Payload(ActionType::ERROR_INVALID_BASE);
+                return ActionType::ERROR_INVALID_BASE;
             }
-            return Payload(
-                (typeflags & NumberType::Float) ? m_parser.as_pyfloat(true, false)
-                                                : m_parser.as_pyint()
-            );
+            return (typeflags & NumberType::Float) ? m_parser.as_pyfloat(true, false)
+                                                   : m_parser.as_pyint();
         }
         Py_UNREACHABLE();
     }
@@ -159,23 +157,23 @@ private:
             return from_text_as_int();
 
         } else if (force_int && (m_parser.peek_inf() || m_parser.peek_nan())) {
-            return Payload(ActionType::ERROR_INVALID_INT);
+            return ActionType::ERROR_INVALID_INT;
 
         } else {
             // Special-case handling of infinity and NaN
             if (m_parser.peek_inf()) {
-                return Payload(inf_action(m_parser.is_negative()));
+                return inf_action(m_parser.is_negative());
             } else if (m_parser.peek_nan()) {
-                return Payload(nan_action(m_parser.is_negative()));
+                return nan_action(m_parser.is_negative());
             }
 
             // Otherwise, attempt to convert to a python float
             // and optionally make as integer and if not signal an error.
             PyObject* result = m_parser.as_pyfloat(force_int, options().allow_coerce());
             if (m_parser.errored()) {
-                return Payload(ActionType::ERROR_INVALID_FLOAT);
+                return ActionType::ERROR_INVALID_FLOAT;
             }
-            return Payload(result);
+            return result;
         }
     }
 
@@ -184,18 +182,18 @@ private:
     {
         // Special-case handling of infinity and NaN
         if (m_parser.peek_inf()) {
-            return Payload(inf_action(m_parser.is_negative()));
+            return inf_action(m_parser.is_negative());
         } else if (m_parser.peek_nan()) {
-            return Payload(nan_action(m_parser.is_negative()));
+            return nan_action(m_parser.is_negative());
         }
 
         // Otherwise, attempt to convert to a python float
         // and if not signal an error.
         PyObject* result = m_parser.as_pyfloat();
         if (m_parser.errored()) {
-            return Payload(ActionType::ERROR_INVALID_FLOAT);
+            return ActionType::ERROR_INVALID_FLOAT;
         }
-        return Payload(result);
+        return result;
     }
 
     /// Logic for evaluating a text python object as an int
@@ -206,7 +204,7 @@ private:
         // so check that first.
         if (m_parser.options().get_base() != 10) {
             if (m_parser.illegal_explicit_base()) {
-                return Payload(ActionType::ERROR_ILLEGAL_EXPLICIT_BASE);
+                return ActionType::ERROR_ILLEGAL_EXPLICIT_BASE;
             }
         }
 
@@ -214,9 +212,9 @@ private:
         // and if not signal an error.
         PyObject* result = m_parser.as_pyint();
         if (m_parser.errored()) {
-            return Payload(ActionType::ERROR_INVALID_INT);
+            return ActionType::ERROR_INVALID_INT;
         }
-        return Payload(result);
+        return result;
     }
 
     /// Return an error due to a bad type
@@ -224,15 +222,15 @@ private:
     {
         if (ntype == UserType::REAL || ntype == UserType::FLOAT) {
             if (type) {
-                return Payload(ActionType::ERROR_BAD_TYPE_FLOAT);
+                return ActionType::ERROR_BAD_TYPE_FLOAT;
             } else {
-                return Payload(ActionType::ERROR_INVALID_FLOAT);
+                return ActionType::ERROR_INVALID_FLOAT;
             }
         } else {
             if (type) {
-                return Payload(ActionType::ERROR_BAD_TYPE_INT);
+                return ActionType::ERROR_BAD_TYPE_INT;
             } else {
-                return Payload(ActionType::ERROR_INVALID_INT);
+                return ActionType::ERROR_INVALID_INT;
             }
         }
     }

--- a/include/fastnumbers/evaluator.hpp
+++ b/include/fastnumbers/evaluator.hpp
@@ -247,7 +247,7 @@ private:
                 },
 
                 // For errors, convert from "raw" errors to "action" errors
-                [this, ntype](const ErrorType err) -> Payload {
+                [ntype](const ErrorType err) -> Payload {
                     // NOTE: We explicitly are not handling ErrorType:OVERFLOW_
                     // because it cannot be returned in the PyObject* code path.
                     if (err == ErrorType::BAD_VALUE) {

--- a/include/fastnumbers/evaluator.hpp
+++ b/include/fastnumbers/evaluator.hpp
@@ -59,9 +59,6 @@ public:
     {
         // Send to the appropriate convenience function based on the found type
         switch (parser_type()) {
-        case ParserType::NUMERIC:
-            return from_numeric_as_type(ntype);
-
         case ParserType::UNICODE:
             if (!options().allow_unicode()) {
                 return typed_error(ntype, false);
@@ -69,8 +66,10 @@ public:
             /* DELIBERATE FALL-THROUGH */
         case ParserType::CHARACTER:
             return from_text_as_type(ntype);
+
+        default: // NUMERIC
+            return from_numeric_as_type(ntype);
         }
-        Py_UNREACHABLE();
     }
 
 private:
@@ -111,9 +110,7 @@ private:
                 return convert(m_parser.as_pyfloat(), ntype);
             }
 
-        case UserType::INT:
-        case UserType::INTLIKE:
-        case UserType::FORCEINT:
+        default: // INT, INTLIKE, FORCEINT
             if (!options().is_default_base()) {
                 return ActionType::ERROR_INVALID_BASE;
             }
@@ -123,26 +120,22 @@ private:
                 ntype
             );
         }
-        Py_UNREACHABLE();
     }
 
     /// Logic for evaluating a text python object
     Payload from_text_as_type(const UserType ntype)
     {
         switch (ntype) {
-        case UserType::REAL:
-        case UserType::INTLIKE:
-        case UserType::FORCEINT:
-            // REAL will only try to coerce to integer... the others will force
-            return from_text_as_int_or_float(ntype != UserType::REAL);
-
         case UserType::FLOAT:
             return from_text_as_float();
 
         case UserType::INT:
             return from_text_as_int();
+
+        default: // REAL, FORCEINT, INTLIKE
+            // REAL will only try to coerce to integer... the others will force
+            return from_text_as_int_or_float(ntype != UserType::REAL);
         }
-        Py_UNREACHABLE();
     }
 
     /// Logic for evaluating a text python object as a float or integer

--- a/include/fastnumbers/extractor.hpp
+++ b/include/fastnumbers/extractor.hpp
@@ -1,125 +1,22 @@
 #pragma once
 
-#include <climits>
-#include <cstddef>
+#include <variant>
 
 #include <Python.h>
 
+#include "fastnumbers/buffer.hpp"
 #include "fastnumbers/parser.hpp"
-#include "fastnumbers/payload.hpp"
+#include "fastnumbers/user_options.hpp"
+
+/// Can store any possible parser
+using AnyParser = std::variant<CharacterParser, UnicodeParser, NumericParser>;
 
 /**
- * \class TextExtractor
- * \brief Extract text data from an object
+ * \brief Return the appropriate parser for the conained data
+ * \param obj The Python object from which to extract data
+ * \param buffer The buffer into which to potentially store data
+ * \param options A UserOptions instance containing the options
+ *                specified by the user.
+ * \return std::variant of CharacterParser, UnicodeParser, or NumericParser
  */
-class TextExtractor {
-public:
-    /// Constructor from a Python object
-    TextExtractor(PyObject* obj, Buffer& buffer)
-        : m_obj(obj)
-        , m_char_buffer(buffer)
-        , m_str(nullptr)
-        , m_str_len(0)
-        , m_uchar(0)
-        , m_negative(false)
-        , m_explicit_base_allowed(true)
-    {
-        Py_INCREF(m_obj);
-        PyNumberMethods* nmeth = Py_TYPE(m_obj)->tp_as_number;
-        const bool user_numeric
-            = nmeth && (nmeth->nb_index || nmeth->nb_int || nmeth->nb_float);
-        if (!user_numeric) {
-            extract_string_data();
-        }
-        m_char_buffer.reset();
-    }
-
-    // Other constructors, destructors, and assignment
-    TextExtractor() = delete;
-    TextExtractor(const TextExtractor&) = delete;
-    TextExtractor(TextExtractor&&) = delete;
-    TextExtractor& operator=(const TextExtractor&) = delete;
-    ~TextExtractor() { Py_DECREF(m_obj); }
-
-    /// Is text stored in this extractor?
-    bool is_text() const { return m_str != nullptr; }
-
-    /// Is a unicode character in this extractor?
-    bool is_unicode_character() const { return m_uchar != 0; }
-
-    /// Is there no text?
-    bool is_non_text() const { return !(is_text() || is_unicode_character()); }
-
-    /**
-     * \brief Return a CharacterParser for the conained data
-     *
-     * Call is_text first to ensue it is valid
-     * to create this parser.
-     *
-     * \param options A UserOptions instance containing the options
-     *                specified by the user.
-     *
-     * \return CharacterParser
-     */
-    CharacterParser text_parser(const UserOptions& options) const
-    {
-        return CharacterParser(m_str, m_str_len, options, m_explicit_base_allowed);
-    }
-
-    /**
-     * \brief Return a UnicodeParser for the conained data
-     *
-     * Call is_unicode_character first to ensue it is valid
-     * to create this parser.
-     *
-     * \param options A UserOptions instance containing the options
-     *                specified by the user.
-     *
-     * \return UnicodeParser
-     */
-    UnicodeParser unicode_char_parser(const UserOptions& options) const
-    {
-        return UnicodeParser(m_uchar, m_negative, options);
-    }
-
-private:
-    /// The Python object under evaluation
-    PyObject* m_obj;
-
-    /// Buffer object into which to store character data
-    Buffer& m_char_buffer;
-
-    /// Pointer to string data
-    const char* m_str;
-
-    /// The length of the string
-    std::size_t m_str_len;
-
-    /// A single unicode characgter that is read
-    Py_UCS4 m_uchar;
-
-    /// Whether or not the unicode character was negative
-    bool m_negative;
-
-    /// Whether or not an explict base is allowed for text processing
-    bool m_explicit_base_allowed;
-
-private:
-    /// Generate a text parsing Parser object
-    void extract_string_data();
-
-    /// Obtain character data from a Python unicode object
-    bool extract_from_unicode();
-
-    /// Obtain character data from a Python bytes object
-    bool extract_from_bytes();
-
-    /// Obtain character data from a Python bytearray object
-    bool extract_from_bytearray();
-
-    /// Obtain character data from a Python buffer object
-    bool extract_from_buffer();
-
-    /// Parse unicode data and convert to character data
-    bool parse_unicode_to_char();
-};
+AnyParser extract_parser(PyObject* obj, Buffer& buffer, const UserOptions& options);

--- a/include/fastnumbers/helpers.hpp
+++ b/include/fastnumbers/helpers.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+/// Always evaluates to false - helps with static_assert messages
+template <class>
+inline constexpr bool always_false_v = false;

--- a/include/fastnumbers/helpers.hpp
+++ b/include/fastnumbers/helpers.hpp
@@ -3,3 +3,12 @@
 /// Always evaluates to false - helps with static_assert messages
 template <class>
 inline constexpr bool always_false_v = false;
+
+/// Aid in constructing multiple overloads from lambdas for std::visit
+/// See https://en.cppreference.com/w/cpp/utility/variant/visit
+template <class... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;

--- a/include/fastnumbers/parser/base.hpp
+++ b/include/fastnumbers/parser/base.hpp
@@ -8,6 +8,7 @@
 
 #include <Python.h>
 
+#include "fastnumbers/helpers.hpp"
 #include "fastnumbers/third_party/EnumClass.h"
 #include "fastnumbers/user_options.hpp"
 
@@ -219,7 +220,7 @@ protected:
             if constexpr (t1_max < t2_max) {
                 if constexpr (std::is_signed_v<T1>) { // T2 is unsigned
                     static_assert(
-                        std::is_signed_v<T1> && std::is_unsigned_v<T2>,
+                        always_false_v<T1> && always_false_v<T2>,
                         "cast from unsigned to signed not supported"
                     );
                 } else { // T2 is signed, T1 unsigned

--- a/include/fastnumbers/parser/character.hpp
+++ b/include/fastnumbers/parser/character.hpp
@@ -151,6 +151,17 @@ public:
         return static_cast<T>(result);
     }
 
+    /**
+     * \brief Convert the contained value into a number C++
+     *
+     * You will need to check for conversion errors and overflows.
+     */
+    template <typename T>
+    void as_number(T& value)
+    {
+        value = as_number<T>();
+    }
+
 private:
     /// The potential start of the character array
     const char* m_start;

--- a/include/fastnumbers/parser/numeric.hpp
+++ b/include/fastnumbers/parser/numeric.hpp
@@ -24,9 +24,6 @@ public:
         const NumberFlags flags = get_number_type();
         set_number_type(flags);
 
-        // Increment the reference count for this object
-        Py_INCREF(m_obj);
-
         // Record the sign
         // XXX: We are cheating a bit here - we are only getting the sign
         // for simple floats because we *know* that that is the only time
@@ -40,13 +37,11 @@ public:
     // No default constructor
     NumericParser() = delete;
 
-    // Default copy/assignment
+    // Default copy/assignment/destruction
     NumericParser(const NumericParser&) = default;
     NumericParser(NumericParser&&) = default;
     NumericParser& operator=(const NumericParser&) = default;
-
-    /// Descructor decreases reference count of the stored object
-    ~NumericParser() { Py_DECREF(m_obj); };
+    ~NumericParser() = default;
 
     /// Convert the stored object to a python int (check error state)
     PyObject* as_pyint() override

--- a/include/fastnumbers/parser/numeric.hpp
+++ b/include/fastnumbers/parser/numeric.hpp
@@ -5,6 +5,7 @@
 
 #include <Python.h>
 
+#include "fastnumbers/helpers.hpp"
 #include "fastnumbers/parser/base.hpp"
 #include "fastnumbers/user_options.hpp"
 
@@ -171,8 +172,7 @@ public:
                 );
             } else {
                 static_assert(
-                    !std::is_integral_v<T>,
-                    "invalid type given to NumericParser::as_number()"
+                    always_false_v<T>, "invalid type given to NumericParser::as_number()"
                 );
             }
         }

--- a/include/fastnumbers/parser/numeric.hpp
+++ b/include/fastnumbers/parser/numeric.hpp
@@ -153,7 +153,7 @@ public:
             }
 
             // Lambda used to pass a value into a RawPayload<T> object
-            auto pass_value = [this](const auto value) -> RawPayload<T> {
+            auto pass_value = [&](const auto value) -> RawPayload<T> {
                 return cast_num_check_overflow<T>(value);
             };
 

--- a/include/fastnumbers/parser/numeric.hpp
+++ b/include/fastnumbers/parser/numeric.hpp
@@ -173,6 +173,17 @@ public:
         }
     }
 
+    /**
+     * \brief Convert the contained value into a number C++
+     *
+     * You will need to check for conversion errors and overflows.
+     */
+    template <typename T>
+    void as_number(T& value)
+    {
+        value = as_number<T>();
+    }
+
 private:
     /// The Python object potentially under analysis
     PyObject* m_obj;

--- a/include/fastnumbers/parser/unicode.hpp
+++ b/include/fastnumbers/parser/unicode.hpp
@@ -153,6 +153,17 @@ public:
         return static_cast<T>((ntype & NumberType::Integer) ? m_digit : m_numeric);
     }
 
+    /**
+     * \brief Convert the contained value into a number C++
+     *
+     * You will need to check for conversion errors and overflows.
+     */
+    template <typename T>
+    void as_number(T& value)
+    {
+        value = as_number<T>();
+    }
+
 private:
     /// The potential numeric value of a unicode character
     double m_numeric;

--- a/include/fastnumbers/parser/unicode.hpp
+++ b/include/fastnumbers/parser/unicode.hpp
@@ -6,6 +6,7 @@
 #include <Python.h>
 
 #include "fastnumbers/parser/base.hpp"
+#include "fastnumbers/payload.hpp"
 #include "fastnumbers/user_options.hpp"
 
 /**
@@ -36,34 +37,29 @@ public:
     UnicodeParser& operator=(const UnicodeParser&) = default;
     ~UnicodeParser() = default;
 
-    /// Convert the stored object to a python int (check error state)
-    PyObject* as_pyint() override
+    /// Convert the stored object to a python int
+    RawPayload<PyObject*> as_pyint() const override
     {
-        reset_error();
         if (get_number_type() & NumberType::Integer) {
             return PyLong_FromLong(m_digit);
         }
-        encountered_conversion_error();
-        return nullptr;
+        return ErrorType::BAD_VALUE;
     }
 
     /**
      * \brief Convert the stored object to a python float but possibly
-     *        coerce to an integer (check error state)
+     *        coerce to an integer
      * \param force_int Force the output to integer (takes precidence)
      * \param coerce Return as integer if the float is int-like
      */
-    PyObject*
-    as_pyfloat(const bool force_int = false, const bool coerce = false) override
+    RawPayload<PyObject*>
+    as_pyfloat(const bool force_int = false, const bool coerce = false) const override
     {
-        reset_error();
-
         const NumberFlags ntype = get_number_type();
 
         // Quit here if not a valid number
         if (!(ntype & (NumberType::Integer | NumberType::Float))) {
-            encountered_conversion_error();
-            return nullptr;
+            return ErrorType::BAD_VALUE;
         }
 
         if (force_int) {
@@ -115,14 +111,12 @@ public:
      * You will need to check for conversion errors and overflows.
      */
     template <typename T, typename std::enable_if_t<std::is_integral_v<T>, bool> = true>
-    T as_number()
+    RawPayload<T> as_number() const
     {
-        reset_error();
         if (get_number_type() & NumberType::Integer) {
             return cast_num_check_overflow<T>(m_digit);
         }
-        encountered_conversion_error();
-        return static_cast<T>(0);
+        return ErrorType::BAD_VALUE;
     }
 
     /**
@@ -135,16 +129,13 @@ public:
     template <
         typename T,
         typename std::enable_if_t<std::is_floating_point_v<T>, bool> = true>
-    T as_number()
+    RawPayload<T> as_number() const
     {
-        reset_error();
-
         const NumberFlags ntype = get_number_type();
 
         // Quit here if not a valid number
         if (!(ntype & (NumberType::Integer | NumberType::Float))) {
-            encountered_conversion_error();
-            return static_cast<T>(0.0);
+            return ErrorType::BAD_VALUE;
         }
 
         // Cast to the desired output type. No need to worry about overflow
@@ -159,7 +150,7 @@ public:
      * You will need to check for conversion errors and overflows.
      */
     template <typename T>
-    void as_number(T& value)
+    void as_number(RawPayload<T>& value) const
     {
         value = as_number<T>();
     }

--- a/include/fastnumbers/payload.hpp
+++ b/include/fastnumbers/payload.hpp
@@ -20,6 +20,13 @@ enum class ActionType {
     ERROR_ILLEGAL_EXPLICIT_BASE, ///< Raise illegal explict base exception
 };
 
+/// The types of errors this class can encounter
+enum class ErrorType {
+    BAD_VALUE, ///< Error because the given value was not valid
+    OVERFLOW_, ///< Error because the given value was out-of-range
+    TYPE_ERROR, ///< Error because the input was not of correct type
+};
+
 /**
  * \brief Transfer data intended to be converted to Python objects
  *
@@ -28,3 +35,12 @@ enum class ActionType {
  * transfer into "Python-land".
  */
 using Payload = std::variant<PyObject*, ActionType>;
+
+template <typename T>
+/**
+ * \brief Transfer data intended to be kept as C-types
+ *
+ * Use of this class removes the need to keep track of error state
+ * after returning a value.
+ */
+using RawPayload = std::variant<T, ErrorType>;

--- a/include/fastnumbers/payload.hpp
+++ b/include/fastnumbers/payload.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <variant>
+
 #include <Python.h>
 
 #include "fastnumbers/user_options.hpp"
 
 /// Possible actions that can be performed on input objects
 enum class ActionType {
-    PY_OBJECT, ///< Return a PyObject*
     NAN_ACTION, ///< Return NaN
     INF_ACTION, ///< Return infinity
     NEG_NAN_ACTION, ///< Return negative NaN
@@ -26,42 +27,4 @@ enum class ActionType {
  * on user parameters. This class uniformly stores all types for smoothest
  * transfer into "Python-land".
  */
-class Payload {
-public:
-    /// Default construct
-    Payload()
-        : m_actval(ActionType::PY_OBJECT)
-        , m_pyval(nullptr)
-    { }
-
-    /// Construct the payload with an action.
-    explicit Payload(const ActionType atype)
-        : m_actval(atype)
-        , m_pyval(nullptr)
-    { }
-
-    /// Construct the payload with a PyObject*.
-    explicit Payload(PyObject* val)
-        : m_actval(ActionType::PY_OBJECT)
-        , m_pyval(val)
-    { }
-
-    // Copy, assignment, and destruct are defaults
-    Payload(const Payload&) = default;
-    Payload(Payload&&) = default;
-    Payload& operator=(const Payload&) = default;
-    ~Payload() = default;
-
-    /// Return the Payload as an ActionType.
-    ActionType get_action() const { return m_actval; }
-
-    /// Return the Payload as a PyObject*.
-    PyObject* to_pyobject() const { return m_pyval; }
-
-private:
-    /// Tracker of what action is being requested
-    ActionType m_actval;
-
-    /// The Payload as a PyObject*
-    PyObject* m_pyval;
-};
+using Payload = std::variant<PyObject*, ActionType>;

--- a/include/fastnumbers/resolver.hpp
+++ b/include/fastnumbers/resolver.hpp
@@ -64,7 +64,7 @@ public:
             overloaded {
 
                 // If the payload contains a Python object, just return directly
-                [*this](PyObject* retval) -> PyObject* {
+                [this](PyObject* retval) -> PyObject* {
                     if (retval == nullptr) {
                         return fail_action();
                     }
@@ -72,7 +72,7 @@ public:
                 },
 
                 // If the payload contains an action type, act on it
-                [*this](const ActionType atype) -> PyObject* {
+                [this](const ActionType atype) -> PyObject* {
                     switch (atype) {
                     // Return the appropriate value for when infinity is found
                     case ActionType::INF_ACTION:

--- a/include/fastnumbers/resolver.hpp
+++ b/include/fastnumbers/resolver.hpp
@@ -228,14 +228,6 @@ private:
             );
             break;
 
-        case ActionType::ERROR_ILLEGAL_EXPLICIT_BASE: // TODO - duplciate
-            // Raise an exception due to useing an explict integer base where it
-            // shouldn't
-            PyErr_SetString(
-                PyExc_TypeError, "int() can't convert non-string with explicit base"
-            );
-            break;
-
         case ActionType::ERROR_INVALID_INT:
             // Raise an exception due to an invalid integer
             PyErr_Format(
@@ -253,15 +245,14 @@ private:
             );
             break;
 
-        case ActionType::ERROR_INVALID_BASE: // TODO - duplciate
+        default:
+            // ERROR_ILLEGAL_EXPLICIT_BASE
+            // ERROR_INVALID_BASE
             // Raise an exception due to an invalid base for integer conversion
             PyErr_SetString(
                 PyExc_TypeError, "int() can't convert non-string with explicit base"
             );
             break;
-
-        default:
-            Py_UNREACHABLE();
         }
 
         return nullptr;

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ else:
     if sys.platform == "darwin":
         compile_args.append("-mmacosx-version-min=10.13")
     if "FN_DEBUG" in os.environ or "FN_COV" in os.environ:
-        compile_args.append("-O0")
+        compile_args.append("-Og")
         compile_args.append("-g")
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ else:
         "-Weffc++",
         "-Wpedantic",
     ]
+    if sys.platform == "darwin":
+        compile_args.append("-mmacosx-version-min=10.13")
     if "FN_DEBUG" in os.environ or "FN_COV" in os.environ:
         compile_args.append("-O0")
         compile_args.append("-g")

--- a/src/cpp/extractor.cpp
+++ b/src/cpp/extractor.cpp
@@ -1,96 +1,106 @@
-#include <cstring>
-#include <stdexcept>
+#include <cstddef>
+#include <variant>
 
 #include <Python.h>
 
+#include "fastnumbers/buffer.hpp"
 #include "fastnumbers/extractor.hpp"
 #include "fastnumbers/parser.hpp"
+#include "fastnumbers/user_options.hpp"
 
-void TextExtractor::extract_string_data()
-{
-    // Use short-circuit logic to extract string data from the python object
-    // from most likely to least likely.
-    extract_from_unicode() || extract_from_bytes() || extract_from_bytearray()
-        || extract_from_buffer();
-}
+// Forward declarations
+using CharUniParser = std::variant<CharacterParser, UnicodeParser>;
+CharUniParser
+parse_unicode_to_char(PyObject* obj, Buffer& char_buffer, const UserOptions& options);
 
-bool TextExtractor::extract_from_unicode()
+AnyParser extract_parser(PyObject* obj, Buffer& buffer, const UserOptions& options)
 {
-    if (PyUnicode_Check(m_obj)) {
+    buffer.reset();
+
+    // Checking if the object is numeric is very fast and easy. Do it
+    // first. It also handles the case where a string subclass implements
+    // a numeric method (in which case it is supposed to be considered numeric).
+    PyNumberMethods* nmeth = Py_TYPE(obj)->tp_as_number;
+    const bool is_numeric
+        = nmeth && (nmeth->nb_index || nmeth->nb_int || nmeth->nb_float);
+    if (is_numeric) {
+        return NumericParser(obj, options);
+    }
+
+    // str, bytes, and bytearray objects can just have the string extracted
+    // directly. The only exception is if the str is not stored as ASCII
+    // in which case we have to do some special transformations.
+    if (PyUnicode_Check(obj)) {
         // Unicode in ASCII form is stored like bytes!
-        if (PyUnicode_IS_READY(m_obj) && PyUnicode_IS_COMPACT_ASCII(m_obj)) {
-            m_str = (const char*)PyUnicode_1BYTE_DATA(m_obj);
-            m_str_len = static_cast<const std::size_t>(PyUnicode_GET_LENGTH(m_obj));
-            return true;
+        if (PyUnicode_IS_READY(obj) && PyUnicode_IS_COMPACT_ASCII(obj)) {
+            return CharacterParser(
+                (const char*)PyUnicode_1BYTE_DATA(obj),
+                static_cast<const std::size_t>(PyUnicode_GET_LENGTH(obj)),
+                options
+            );
         }
-        return parse_unicode_to_char();
-    }
-    return false;
-}
 
-bool TextExtractor::extract_from_bytes()
-{
-    if (PyBytes_Check(m_obj)) {
-        m_str = PyBytes_AS_STRING(m_obj);
-        m_str_len = static_cast<const std::size_t>(PyBytes_GET_SIZE(m_obj));
-        return true;
+        // Here is the special-case handling for non-ASCII unicode.
+        auto parser = parse_unicode_to_char(obj, buffer, options);
+        if (std::holds_alternative<CharacterParser>(parser)) {
+            return std::get<CharacterParser>(parser);
+        } else {
+            return std::get<UnicodeParser>(parser);
+        }
+    } else if (PyBytes_Check(obj)) {
+        return CharacterParser(
+            PyBytes_AS_STRING(obj),
+            static_cast<const std::size_t>(PyBytes_GET_SIZE(obj)),
+            options
+        );
+    } else if (PyByteArray_Check(obj)) {
+        return CharacterParser(
+            PyByteArray_AS_STRING(obj),
+            static_cast<const std::size_t>(PyByteArray_GET_SIZE(obj)),
+            options
+        );
     }
-    return false;
-}
 
-bool TextExtractor::extract_from_bytearray()
-{
-    if (PyByteArray_Check(m_obj)) {
-        m_str = PyByteArray_AS_STRING(m_obj);
-        m_str_len = static_cast<const std::size_t>(PyByteArray_GET_SIZE(m_obj));
-        return true;
-    }
-    return false;
-}
-
-bool TextExtractor::extract_from_buffer()
-{
+    // A less-common case is a memory buffer, which requires a bit extra
+    // handling compared to the above.
     Py_buffer view = { nullptr, nullptr };
-    if (PyObject_CheckBuffer(m_obj)
-        && PyObject_GetBuffer(m_obj, &view, PyBUF_SIMPLE) == 0) {
+    if (PyObject_CheckBuffer(obj) && PyObject_GetBuffer(obj, &view, PyBUF_SIMPLE) == 0) {
         // NOTE: PyBUF_SIMPLE implies zero-dimensional byte data.
         // This buffer could be a memoryview slice. If this is the case, the
         // nul termination of the string will be past the given length, creating
         // unexpected parsing results. Rather than complicate the parsing and
         // adding more operations for a low probability event, a copy of the
         // slice will be made here and null termination will be added.
-        // If the data amount is small enough, we use a fixed-sized buffer for speed.
-        m_str_len = static_cast<const std::size_t>(view.len);
-        m_char_buffer.reserve(m_str_len + 1);
-        m_char_buffer.start()[m_str_len] = '\0';
-        PyBuffer_ToContiguous(m_char_buffer.start(), &view, m_str_len, 'A');
+        const std::size_t len = static_cast<const std::size_t>(view.len);
+        buffer.reserve(len + 1);
+        PyBuffer_ToContiguous(buffer.start(), &view, len, 'A');
+        buffer.start()[len] = '\0';
 
         // All we care about is the underlying buffer data, not the obj
         // which was allocated when we created the buffer. For this reason
         // it is safe to release the buffer here.
         PyBuffer_Release(&view);
-        m_str = m_char_buffer.start();
-        m_explicit_base_allowed = false;
-        return true;
+        return CharacterParser(buffer.start(), len, options, false);
     }
-    return false;
+
+    // If here, we have no idea what the type is. The NumericParser is
+    // responsible for handling type errors.
+    return NumericParser(obj, options);
 }
 
-bool TextExtractor::parse_unicode_to_char()
+/// Obtain either a CharacterParser or UnicodeParser from unicode data
+CharUniParser
+parse_unicode_to_char(PyObject* obj, Buffer& char_buffer, const UserOptions& options)
 {
-    const unsigned kind = PyUnicode_KIND(m_obj); // Unicode storage format.
-    const void* data = PyUnicode_DATA(m_obj); // Raw data
-    Py_ssize_t len = PyUnicode_GET_LENGTH(m_obj);
+    const unsigned kind = PyUnicode_KIND(obj); // Unicode storage format.
+    const void* data = PyUnicode_DATA(obj); // Raw data
+    Py_ssize_t len = PyUnicode_GET_LENGTH(obj);
     Py_ssize_t index = 0;
-
-    // Default the results to "nothing" so we don't have to for each error case below
-    m_char_buffer.start()[0] = '\0';
-    m_str = m_char_buffer.start();
 
     // Ensure input is a valid unicode object.
     // If true, then not OK for conversion - unclear how this can happen...
-    if (PyUnicode_READY(m_obj)) {
-        return true;
+    if (PyUnicode_READY(obj)) {
+        return CharacterParser("", 0, options);
     }
 
     // Strip whitespace from both ends of the data.
@@ -105,17 +115,17 @@ bool TextExtractor::parse_unicode_to_char()
     }
 
     // Remember if it was negative
-    m_negative = PyUnicode_READ(kind, data, index) == '-';
+    const bool negative = PyUnicode_READ(kind, data, index) == '-';
 
     // Protect against attempting to allocate too much memory
-    if (static_cast<std::size_t>(len) + 1 > m_char_buffer.max_size()) {
-        return true;
+    if (static_cast<std::size_t>(len) + 1 > char_buffer.max_size()) {
+        return CharacterParser("", 0, options);
     }
 
     // Allocate space for the character data, but use a small fixed size
     // buffer if the data is small enough. Ensure a trailing null character.
-    m_char_buffer.reserve(static_cast<std::size_t>(len) + 1);
-    char* buffer = m_char_buffer.start();
+    char_buffer.reserve(static_cast<std::size_t>(len) + 1);
+    char* buffer = char_buffer.start();
     std::size_t buffer_index = 0;
 
     // Iterate over the unicode data and transform to ASCII-compatible
@@ -135,19 +145,13 @@ bool TextExtractor::parse_unicode_to_char()
             buffer[buffer_index] = ' ';
         } else {
             if (len == 1) {
-                m_uchar = u;
-                m_str = nullptr;
-                return true;
+                return UnicodeParser(u, negative, options);
             }
-            buffer[0] = '\0';
-            m_str = buffer;
-            return true;
+            return CharacterParser("", 0, options);
         }
         buffer_index += 1;
     }
     buffer[buffer_index] = '\0';
 
-    m_str = buffer;
-    m_str_len = buffer_index;
-    return true;
+    return CharacterParser(buffer, buffer_index, options);
 }

--- a/src/cpp/extractor.cpp
+++ b/src/cpp/extractor.cpp
@@ -9,8 +9,7 @@
 #include "fastnumbers/user_options.hpp"
 
 // Forward declarations
-using CharUniParser = std::variant<CharacterParser, UnicodeParser>;
-CharUniParser
+AnyParser
 parse_unicode_to_char(PyObject* obj, Buffer& char_buffer, const UserOptions& options);
 
 AnyParser extract_parser(PyObject* obj, Buffer& buffer, const UserOptions& options)
@@ -41,12 +40,7 @@ AnyParser extract_parser(PyObject* obj, Buffer& buffer, const UserOptions& optio
         }
 
         // Here is the special-case handling for non-ASCII unicode.
-        auto parser = parse_unicode_to_char(obj, buffer, options);
-        if (std::holds_alternative<CharacterParser>(parser)) {
-            return std::get<CharacterParser>(parser);
-        } else {
-            return std::get<UnicodeParser>(parser);
-        }
+        return parse_unicode_to_char(obj, buffer, options);
     } else if (PyBytes_Check(obj)) {
         return CharacterParser(
             PyBytes_AS_STRING(obj),
@@ -89,7 +83,7 @@ AnyParser extract_parser(PyObject* obj, Buffer& buffer, const UserOptions& optio
 }
 
 /// Obtain either a CharacterParser or UnicodeParser from unicode data
-CharUniParser
+AnyParser
 parse_unicode_to_char(PyObject* obj, Buffer& char_buffer, const UserOptions& options)
 {
     const unsigned kind = PyUnicode_KIND(obj); // Unicode storage format.

--- a/src/cpp/implementation.cpp
+++ b/src/cpp/implementation.cpp
@@ -3,6 +3,7 @@
  */
 #include <limits>
 #include <string_view>
+#include <variant>
 
 #include <Python.h>
 
@@ -32,22 +33,16 @@ collect_payload(PyObject* obj, const UserOptions& options, const UserType ntype)
 {
     Buffer buffer;
 
-    // The text extractor is responsible for taking a python object
-    // and returning either a char array or single unicode character.
-    // Depending on what would be returned, we pass the data to the
-    // appropriate parser, and this parser is then passed to the evaluator
-    // to decide how to convert the data into the appropriate payload.
-    TextExtractor extractor(obj, buffer);
-    if (extractor.is_text()) {
-        CharacterParser cparser = extractor.text_parser(options);
-        return Evaluator<CharacterParser>(obj, options, cparser).as_type(ntype);
-    } else if (extractor.is_unicode_character()) {
-        UnicodeParser uparser = extractor.unicode_char_parser(options);
-        return Evaluator<UnicodeParser>(obj, options, uparser).as_type(ntype);
-    } else {
-        NumericParser nparser(obj, options);
-        return Evaluator<NumericParser>(obj, options, nparser).as_type(ntype);
-    }
+    // extract_parser() is responsible for taking a python object
+    // and returning the Parser object best suited to parser the object's data.
+    // std:visit is used to obtain the payload data no matter which parser was
+    // returned.
+    return std::visit(
+        [&](auto parser) -> Payload {
+            return Evaluator<decltype(parser)>(obj, options, parser).as_type(ntype);
+        },
+        extract_parser(obj, buffer, options)
+    );
 }
 
 /**
@@ -66,26 +61,25 @@ collect_type(PyObject* obj, const UserOptions& options, const PyObject* consider
     const bool str_only = consider == Selectors::STRING_ONLY;
     Buffer buffer;
 
-    // The text extractor is responsible for taking a python object
-    // and returning either a char array or single unicode character.
-    // Depending on what would be returned, we pass the data to the
-    // appropriate parser, and this parser is then passed to the evaluator
-    // to decide how to convert the data into the appropriate payload.
-    TextExtractor extractor(obj, buffer);
-    if (num_only && (extractor.is_text() || extractor.is_unicode_character())) {
-        return NumberType::INVALID;
-    } else if (str_only && extractor.is_non_text()) {
-        return NumberType::INVALID;
-    } else if (extractor.is_text()) {
-        CharacterParser cparser = extractor.text_parser(options);
-        return Evaluator<CharacterParser>(obj, options, cparser).number_type();
-    } else if (extractor.is_unicode_character()) {
-        UnicodeParser uparser = extractor.unicode_char_parser(options);
-        return Evaluator<UnicodeParser>(obj, options, uparser).number_type();
-    } else {
-        NumericParser nparser(obj, options);
-        return Evaluator<NumericParser>(obj, options, nparser).number_type();
-    }
+    // extract_parser() is responsible for taking a python object
+    // and returning the Parser object best suited to parser the object's data.
+    // std:visit is used to obtain the number flag no matter which parser was
+    // returned.
+    return std::visit(
+        [&](auto parser) -> NumberFlags {
+            if constexpr (std::is_same_v<decltype(parser), NumericParser>) {
+                if (str_only) {
+                    return NumberType::INVALID;
+                }
+            } else {
+                if (num_only) {
+                    return NumberType::INVALID;
+                }
+            }
+            return Evaluator<decltype(parser)>(obj, options, parser).number_type();
+        },
+        extract_parser(obj, buffer, options)
+    );
 }
 
 /**


### PR DESCRIPTION
Change error handling from "check the state after calling" to "I'm returning a type that forces you to check for errors to use it, haha". Doing this enables more const-correctness because state no longer needs to be stored, so parsing objects can be const.

Heavy use of the visitor pattern is now used to handle error checking.

Hopefully this change also improves coverage.

