### PR TITLE
Update pyproject.toml with correct license identifier according to PEP639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dynamic = ["version"]
 requires-python = ">=3.8"
 description = "Super-fast and clean conversions to numbers."
 readme = "README.rst"
-license = {text = "MIT"}
+license = "MIT"
 keywords = ["conversion", "numeric", "performance"]
 classifiers = [
 	"Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR should fix #83 by fixing the license identifier to comply with PEP639. See more information here: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license