### PR TITLE
fix build failure with Python 3.14 by linking libstdc++

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import sys
 from setuptools import Extension, setup
 
 # Compilation arguments are platform-dependent
-link_args = ["-lm"]
+link_args = ["-lm", "-lstdc++"]
 if sys.platform == "win32":
     compile_args = [
         "/std:c++17",
@@ -48,6 +48,7 @@ ext = [
         include_dirs=[str(pathlib.Path("include").resolve())],
         extra_compile_args=compile_args,
         extra_link_args=link_args,
+        language="c++",
     )
 ]
 


### PR DESCRIPTION
Explicitly set 'language="c++"' and add '-lstdc++' to the linker arguments in setup.py via opensuse-build.patch. This ensures that the compiled extension module is properly linked against the standard C++ library on Python 3.14, where the compiler toolchain incorrectly defaults to gcc for linking, avoiding "undefined symbol" ImportError failures during %check.