### PR TITLE
Fix silent miscomputation of base-prefixed underscore strings at base 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Unreleased
 ---
 
+### Fixed
+
+- Fixed `int`, `real`, `try_int` and `try_array` silently accepting and
+  miscomputing a `0b`/`0o`/`0x` prefix combined with an underscore at the
+  default base 10, e.g. `int("0b1_0")` returning `10` instead of raising
+  `ValueError` ([@gaoflow](https://github.com/gaoflow), issue
+  [#91](https://github.com/SethMMorton/fastnumbers/pull/91))
+
 [5.2.0] - 2026-06-27
 ---
 

--- a/include/fastnumbers/parser/character.hpp
+++ b/include/fastnumbers/parser/character.hpp
@@ -100,7 +100,12 @@ public:
             if (base == 0) {
                 base = detect_base(buffer.start(), buffer.end());
             }
-            buffer.remove_base_prefix();
+            // A "0b"/"0o"/"0x" prefix is only valid for a non-decimal base; at base
+            // 10 it is invalid input, so leave it in place to let the re-parse reject
+            // it (otherwise e.g. "0b1_0" would be silently miscomputed as 10).
+            if (base != 10) {
+                buffer.remove_base_prefix();
+            }
             result = parse_int<T>(
                 buffer.start(), buffer.end(), base, error, overflow, always_convert
             );

--- a/src/cpp/parser.cpp
+++ b/src/cpp/parser.cpp
@@ -355,7 +355,12 @@ RawPayload<PyObject*> CharacterParser::as_pyint() const noexcept(false)
         if (base == 0) {
             base = detect_base(buffer.start(), buffer.end());
         }
-        buffer.remove_base_prefix();
+        // A "0b"/"0o"/"0x" prefix is only valid for a non-decimal base; at base 10
+        // it is invalid input, so leave it in place to let the re-parse reject it
+        // (otherwise e.g. "0b1_0" would be silently miscomputed as 10).
+        if (base != 10) {
+            buffer.remove_base_prefix();
+        }
         result = parse_int<int64_t>(buffer.start(), buffer.end(), base, error, overflow);
     }
     if (error) {

--- a/tests/test_builtin_int.py
+++ b/tests/test_builtin_int.py
@@ -242,6 +242,24 @@ class IntTestCases(unittest.TestCase):
         self.assertRaises(ValueError, int, "1__00")
         self.assertRaises(ValueError, int, "100_")
 
+    def test_base_prefix_with_underscore_is_invalid_at_base_10(self) -> None:
+        # A "0b"/"0o"/"0x" prefix is invalid at the default base 10, exactly as
+        # for builtins.int. Combined with an underscore it used to be silently
+        # accepted and miscomputed, e.g. int("0b1_0") -> 10 instead of an error.
+        for prefix in ("0b", "0o", "0x"):
+            for sign in ("", "+", "-"):
+                for body in ("1_0", "9_5", "1_2_3"):
+                    lit = f"{sign}{prefix}{body}"
+                    self.assertRaises(ValueError, builtins.int, lit)
+                    self.assertRaises(ValueError, int, lit)
+                    self.assertRaises(ValueError, int, f"  {lit}  ")
+        # the same literals remain valid (and match builtins.int) when the base
+        # actually permits the prefix, so the fix does not over-reject
+        assert int("0b1_0", 0) == builtins.int("0b1_0", 0) == 2
+        assert int("0b1_0", 2) == 2
+        assert int("0o1_7", 8) == builtins.int("0o1_7", 8) == 15
+        assert int("0x1_f", 16) == builtins.int("0x1_f", 16) == 31
+
     @support.cpython_only
     def test_small_ints(self) -> None:
         # Bug #3236: Return small longs from PyLong_FromString


### PR DESCRIPTION
`fastnumbers.int`/`real` (and the `try_int` / `try_array(dtype=int)` variants) are documented drop-in replacements that "behave identically to the built-in `int`" apart from a few listed exceptions. At the default base 10 they don't: a `0b`/`0o`/`0x` prefix combined with an underscore is silently accepted and miscomputed, where `builtins.int` raises `ValueError`.

```pycon
>>> import builtins, fastnumbers
>>> builtins.int("0b1_0")       # ValueError
>>> fastnumbers.int("0b1_0")    # 10    <- wrong
>>> fastnumbers.int("0x1_2")    # 12    <- wrong
>>> fastnumbers.int("-0b1_0")   # -10   <- wrong
```

It is also internally inconsistent: `check_int("0b1_0")` correctly returns `False` while `int("0b1_0")` returns `10`. The prefix must appear together with an underscore — plain `int("0b10")` and `int("0b_1")` already raise correctly.

### Cause

When the fast integer parse fails and the input has validly-placed underscores, `as_pyint()` (`src/cpp/parser.cpp`) and the array-path `as_number<integral>()` (`include/fastnumbers/parser/character.hpp`) retry after removing the underscores. That retry also calls `buffer.remove_base_prefix()` unconditionally, but `remove_base_prefix()` is base-agnostic: at base 10 it strips the `0b`/`0o`/`0x` that makes the input invalid, so `"0b1_0"` becomes `"0b10"` becomes `"10"` and reparses as decimal `10`. The real error — the prefix letter, invalid at base 10 — is masked.

### Fix

Strip the prefix only when the resolved base is not 10. At base 10 the prefix is invalid input, so leaving it in place lets the reparse reject it correctly. Prefix+underscore inputs at bases that do permit a prefix (0/2/8/16) are unaffected — the guard can only reduce stripping at base 10, so every other base is byte-for-byte unchanged.

`test_base_prefix_with_underscore_is_invalid_at_base_10` covers every `{sign}{prefix}{underscored-body}` form (including whitespace-padded), asserting parity with `builtins.int`, plus positive cases at bases 0/2/8/16 to confirm no over-rejection. The full test suite passes, and `dev/formatting.py --check`, `ruff check` and `mypy --strict tests` are clean.
